### PR TITLE
Introduce new functions to optimise fitting

### DIFF
--- a/sbmtm.py
+++ b/sbmtm.py
@@ -564,6 +564,10 @@ class sbmtm():
     ########### HELPER FUNCTIONS
     ###########
     ## get group-topic statistics
+
+    def get_mdl(self):
+        return self.mdl
+
     def get_groups(self,l=0):
         '''
         extract statistics on group membership of nodes form the inferred state.

--- a/sbmtm.py
+++ b/sbmtm.py
@@ -210,6 +210,23 @@ class sbmtm():
         self.documents = [ self.g.vp['name'][v] for v in  self.g.vertices() if self.g.vp['kind'][v]==0   ]
 
 
+    def dump_model(self, filename="topsbm.pkl"):
+        with open(filename, 'wb') as f:
+            pickle.dump(self, f)
+
+    def load_model(self, filename="topsbm.pkl"):
+        if self.g is not None:
+            del self.g
+        del self.words
+        del self.documents
+        if self.state is not None:
+            del self.state
+        del self.groups
+        del self.mdl
+        del self.L
+        with open(filename, 'rb') as f:
+            self = pickle.load(f)
+
     def fit(self,overlap = False, hierarchical = True, B_min = None, n_init = 1,verbose=False):
         '''
         Fit the sbm to the word-document network.


### PR DESCRIPTION
Introduce some useful functions and parallelise fit:

- fit has argument parallel with pass `{"sequential":False}` to underlying graph tool's functions
- introduce dump and load model to pickle the model (useful to store and recall fitted models)
- introduce `sbmtm.multiflip_mcmc_sweep()` to use `gt.multiflip_mcmc_sweep` greedy approach on the model. This should be [use less memory on big networks](https://graph-tool.skewed.de/static/doc/demos/inference/inference.html#trade-off-between-memory-usage-and-computation-time). This can be called both after loading the graph or after a fit. [[peixoto-merge-split-2020](https://arxiv.org/abs/2003.07070)]
- introduce `sbmtm.get_mdl()` to facilitate access to `model.state.entropy()`
