### PR TITLE
plot_topic_dist happens to access None groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.vscode/settings.json
+.DS_Store

--- a/sbmtm.py
+++ b/sbmtm.py
@@ -738,7 +738,7 @@ class sbmtm():
             self.state.print_summary()
 
     def plot_topic_dist(self, l):
-        groups = self.groups[l]
+        groups = self.get_groups(l)
         p_w_tw = groups['p_w_tw']
         fig=plt.figure(figsize=(12,10))
         plt.imshow(p_w_tw,origin='lower',aspect='auto',interpolation='none')


### PR DESCRIPTION
plot_topic_dist calls self.groups. If plot_topic_dist is the first call after fit() this will fail since groups are not longer stored at the end of the fit function.

plot_topic_dist should properly call self.get_groups() before doing anything else